### PR TITLE
Feat/#9 get promise api

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,7 +33,7 @@ model Conflict {
 model Promise {
   id        Int     @id @default(autoincrement())
   couple_id Int
-  text1     String
+  text1     String?
   text2     String?
   text3     String?
   text4     String?

--- a/src/controllers/promise.controller.js
+++ b/src/controllers/promise.controller.js
@@ -1,70 +1,79 @@
 import { StatusCodes } from 'http-status-codes';
 import { getPromiseByCoupleIdService } from '../services/promise.service.js';
 
-/**
- * @swagger
- * /api/promise/{couple_id}:
- *   get:
- *     summary: 특정 커플의 약속 조회 API
- *     description: 커플 ID를 기반으로 Promise 테이블의 데이터를 조회합니다.
- *     parameters:
- *       - in: path
- *         name: couple_id
- *         required: true
- *         schema:
- *           type: integer
- *           example: 1
- *         description: 조회할 커플 ID
- *     responses:
- *       200:
- *         description: 약속 데이터 조회 성공
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 resultType:
- *                   type: string
- *                   example: SUCCESS
- *                 error:
- *                   type: object
- *                   nullable: true
- *                   example: null
- *                 success:
- *                   type: object
- *                   properties:
- *                     promise_id:
- *                       type: integer
- *                       example: 1
- *                     couple_id:
- *                       type: integer
- *                       example: 1
- *                     text1:
- *                       type: string
- *                       example: "나는 지각하지 않겠습니다."
- *                     text2:
- *                       type: string
- *                       example: "나는 연락을 잘 하겠습니다."
- *                     ...
- *       400:
- *         description: 잘못된 요청
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 resultType:
- *                   type: string
- *                   example: FAIL
- *                 error:
- *                   type: string
- *                   example: Invalid couple_id
- *                 success:
- *                   type: object
- *                   nullable: true
- *                   example: null
- */
 export const getPromiseByCoupleId = async (req, res) => {
+  /**
+    #swagger.summary = '특정 커플의 약속 조회 API';
+    #swagger.description = '커플 ID를 기반으로 Promise 테이블의 데이터를 조회합니다.';
+    #swagger.parameters['couple_id'] = {
+      in: 'path',
+      description: '조회할 커플 ID',
+      required: true,
+      schema: {
+        type: 'integer',
+        example: 1
+      }
+    };
+    #swagger.responses[200] = {
+      description: '약속 데이터 조회 성공',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              resultType: { type: 'string', example: 'SUCCESS' },
+              error: { type: 'object', nullable: true, example: null },
+              success: {
+                type: 'object',
+                properties: {
+                  id: { type: 'integer', example: 1 },
+                  couple_id: { type: 'integer', example: 1 },
+                  text1: { type: 'string', example: '나는 지각하지 않겠습니다.' },
+                  text2: { type: 'string', example: '나는 연락을 잘 하겠습니다.' },
+                  text3: { type: 'string', example: '나는 늦게까지 게임하지 않겠습니다.' },
+                  text4: { type: 'string', example: '나는 상대방의 의견을 존중하겠습니다.' },
+                  text5: { type: 'string', example: null },
+                  text6: { type: 'string', example: null },
+                  text7: { type: 'string', example: null },
+                  text8: { type: 'string', example: null },
+                  text9: { type: 'string', example: null },
+                  text10: { type: 'string', example: null }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+    #swagger.responses[400] = {
+      description: '잘못된 요청',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              resultType: { type: 'string', example: 'FAIL' },
+              error: {
+                type: 'object',
+                properties: {
+                  errorCode: { type: 'string', example: 'CP001' },
+                  reason: { type: 'string', example: 'Couple with id 5 not found.' },
+                  data: {
+                    type: 'object',
+                    properties: {
+                      couple_id: { type: 'string', example: '5' }
+                    }
+                  }
+                }
+              },
+              success: { type: 'object', nullable: true, example: null }
+            }
+          }
+        }
+      }
+    };
+ */
+
   const { couple_id } = req.params;
 
   const promise = await getPromiseByCoupleIdService(couple_id);

--- a/src/controllers/promise.controller.js
+++ b/src/controllers/promise.controller.js
@@ -1,0 +1,72 @@
+import { StatusCodes } from 'http-status-codes';
+import { getPromiseByCoupleIdService } from '../services/promise.service.js';
+
+/**
+ * @swagger
+ * /api/promise/{couple_id}:
+ *   get:
+ *     summary: 특정 커플의 약속 조회 API
+ *     description: 커플 ID를 기반으로 Promise 테이블의 데이터를 조회합니다.
+ *     parameters:
+ *       - in: path
+ *         name: couple_id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           example: 1
+ *         description: 조회할 커플 ID
+ *     responses:
+ *       200:
+ *         description: 약속 데이터 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 resultType:
+ *                   type: string
+ *                   example: SUCCESS
+ *                 error:
+ *                   type: object
+ *                   nullable: true
+ *                   example: null
+ *                 success:
+ *                   type: object
+ *                   properties:
+ *                     promise_id:
+ *                       type: integer
+ *                       example: 1
+ *                     couple_id:
+ *                       type: integer
+ *                       example: 1
+ *                     text1:
+ *                       type: string
+ *                       example: "나는 지각하지 않겠습니다."
+ *                     text2:
+ *                       type: string
+ *                       example: "나는 연락을 잘 하겠습니다."
+ *                     ...
+ *       400:
+ *         description: 잘못된 요청
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 resultType:
+ *                   type: string
+ *                   example: FAIL
+ *                 error:
+ *                   type: string
+ *                   example: Invalid couple_id
+ *                 success:
+ *                   type: object
+ *                   nullable: true
+ *                   example: null
+ */
+export const getPromiseByCoupleId = async (req, res) => {
+  const { couple_id } = req.params;
+
+  const promise = await getPromiseByCoupleIdService(couple_id);
+  res.status(StatusCodes.OK).success(promise);
+};

--- a/src/dtos/promise.dto.js
+++ b/src/dtos/promise.dto.js
@@ -1,0 +1,15 @@
+import { coupleIdNotValidError } from '../errors/promise.error.js';
+import logger from '../logger.js';
+
+//get-promise-api
+export const promiseCoupleIdDTO = couple_id => {
+  logger.debug(couple_id);
+  const parsed_couple_id = parseInt(couple_id, 10);
+  const regex = /^\d+$/; // Check if couple_id consists only of digits
+  if (!regex.test(couple_id)) {
+    throw new coupleIdNotValidError(`Invalid couple_id: ${couple_id}. Must be a valid integer.`, {
+      couple_id: couple_id,
+    });
+  }
+  return { couple_id: parsed_couple_id };
+};

--- a/src/errors/promise.error.js
+++ b/src/errors/promise.error.js
@@ -1,0 +1,19 @@
+export class coupleNotFoundError extends Error {
+  errorCode = 'CP001';
+
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.data = data;
+  }
+}
+
+export class coupleIdNotValidError extends Error {
+  errorCode = 'CP002';
+
+  constructor(reason, data) {
+    super(reason);
+    this.reason = reason;
+    this.data = data;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import swaggerUiExpress from 'swagger-ui-express';
 import swaggerAutogen from 'swagger-autogen';
 import morganMiddleware from './middlewares/morganMiddleware.js';
 import { getConflictsByMonth, getConflictsById } from './controllers/conflict.controller.js';
-
+import { getPromiseByCoupleId } from './controllers/promise.controller.js';
 dotenv.config();
 
 const app = express();
@@ -85,6 +85,7 @@ app.get('/', (req, res) => {
 
 app.get('/api/conflicts/:month', getConflictsByMonth);
 app.get('/api/conflicts/id/:conflict_id', getConflictsById);
+app.get('/api/promise/:couple_id', getPromiseByCoupleId);
 
 /****************전역 오류를 처리하기 위한 미들웨어*******************/
 app.use((err, req, res, next) => {

--- a/src/repositories/promise.repository.js
+++ b/src/repositories/promise.repository.js
@@ -1,0 +1,58 @@
+import { PrismaClient } from '@prisma/client';
+import { coupleNotFoundError } from '../errors/promise.error.js';
+
+const prisma = new PrismaClient();
+
+export const getPromiseByCoupleIdRepository = async couple_id => {
+  const promise = await prisma.promise.findFirst({
+    where: { couple_id },
+    select: {
+      id: true,
+      couple_id: true,
+      text1: true,
+      text2: true,
+      text3: true,
+      text4: true,
+      text5: true,
+      text6: true,
+      text7: true,
+      text8: true,
+      text9: true,
+      text10: true,
+    },
+  });
+  if (!promise) {
+    // Check if the couple_id exists in the Couple table
+    const coupleExists = await prisma.couple.findUnique({
+      where: { couple_id },
+      select: { couple_id: true },
+    });
+
+    if (!coupleExists) {
+      throw new coupleNotFoundError(`Couple with id ${couple_id} not found.`, { couple_id: couple_id });
+    }
+
+    // Log a message if the couple exists but no promise is found
+    const newPromise = await prisma.promise.create({
+      data: {
+        couple: {
+          connect: { couple_id },
+        },
+        text1: null,
+        text2: null,
+        text3: null,
+        text4: null,
+        text5: null,
+        text6: null,
+        text7: null,
+        text8: null,
+        text9: null,
+        text10: null,
+      },
+    });
+
+    return newPromise;
+  }
+
+  return promise;
+};

--- a/src/services/promise.service.js
+++ b/src/services/promise.service.js
@@ -1,0 +1,7 @@
+import { getPromiseByCoupleIdRepository } from '../repositories/promise.repository.js';
+import { promiseCoupleIdDTO } from '../dtos/promise.dto.js';
+
+export const getPromiseByCoupleIdService = async couple_id => {
+  const dto = promiseCoupleIdDTO(couple_id);
+  return await getPromiseByCoupleIdRepository(dto.couple_id);
+};


### PR DESCRIPTION
# 🚀 작업한 기능 설명 (Feature Description)
- 커플의 약속을 가져오는 API를 구현했습니다.

---

## 🔍 작업 상세 (Implementation Details)

### ✅ 성공 응답 예시
```json
{
    "resultType": "SUCCESS",
    "error": null,
    "success": {
        "id": 1,
        "couple_id": 1,
        "text1": "우리는 매달 여행을 떠나기로 약속한다.",
        "text2": "우리는 서로 솔직하고 열린 대화를 나누기로 약속한다.",
        "text3": "우리는 서로의 꿈을 지원하기로 약속한다.",
        "text4": "밤 늦게까지 게임하지 않는다.",
        "text5": "매일 매일 연락한다.",
        "text6": "항상 잘 지낸다.",
        "text7": null,
        "text8": null,
        "text9": null,
        "text10": null
    }
}
```
### ❌ 실패 응답 예시 (유저 조회 실패)
```json
{
    "resultType": "FAIL",
    "error": {
        "errorCode": "CP001",
        "reason": "Couple with id 5 not found.",
        "data": {
            "couple_id": 5
        }
    },
    "success": null
}
```

```
### ❌ 실패 응답 예시 (유효하지 않은 id)
```json
{
    "resultType": "FAIL",
    "error": {
        "errorCode": "CP002",
        "reason": "Invalid couple_id: 5a. Must be a valid integer.",
        "data": {
            "couple_id": "5a"
        }
    },
    "success": null
}
```
