### PR TITLE
✨ feat: Add put-promise-api

### DIFF
--- a/src/controllers/promise.controller.js
+++ b/src/controllers/promise.controller.js
@@ -1,5 +1,5 @@
 import { StatusCodes } from 'http-status-codes';
-import { getPromiseByCoupleIdService } from '../services/promise.service.js';
+import { getPromiseByCoupleIdService, putPromiseByCoupleIdService } from '../services/promise.service.js';
 
 export const getPromiseByCoupleId = async (req, res) => {
   /**
@@ -77,5 +77,134 @@ export const getPromiseByCoupleId = async (req, res) => {
   const { couple_id } = req.params;
 
   const promise = await getPromiseByCoupleIdService(couple_id);
+  res.status(StatusCodes.OK).success(promise);
+};
+
+export const putPromiseByCoupleId = async (req, res) => {
+  /**
+    #swagger.summary = '특정 커플의 약속 수정 및 생성 API';
+    #swagger.description = '커플 ID를 기반으로 Promise 테이블의 약속 데이터를 수정하거나 생성합니다.';
+    #swagger.parameters['couple_id'] = {
+      in: 'path',
+      description: '수정 또는 생성할 커플 ID',
+      required: true,
+      schema: {
+        type: 'integer',
+        example: 1
+      }
+    };
+    #swagger.requestBody = {
+      description: '수정할 약속 데이터',
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              text1: { type: 'string', example: '나는 지각하지 않겠습니다.' },
+              text2: { type: 'string', example: '나는 지각하지 않겠습니다.' },
+              text3: { type: 'string', example: '나는 늦게까지 게임하지 않겠습니다.' },
+              text4: { type: 'string', example: '나는 연락을 잘 하겠습니다.' },
+              text5: { type: 'string', example: null },
+              text6: { type: 'string', example: null },
+              text7: { type: 'string', example: null },
+              text8: { type: 'string', example: null },
+              text9: { type: 'string', example: '끝난거같은데?' },
+              text10: { type: 'string', example: null }
+            }
+          }
+        }
+      }
+    };
+    #swagger.responses[200] = {
+      description: '약속 데이터 수정 또는 생성 성공',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              resultType: { type: 'string', example: 'SUCCESS' },
+              error: { type: 'object', nullable: true, example: null },
+              success: {
+                type: 'object',
+                properties: {
+                  id: { type: 'integer', example: 1 },
+                  couple_id: { type: 'integer', example: 1 },
+                  text1: { type: 'string', example: '나는 지각하지 않겠습니다.' },
+                  text2: { type: 'string', example: '나는 지각하지 않겠습니다.' },
+                  text3: { type: 'string', example: '나는 늦게까지 게임하지 않겠습니다.' },
+                  text4: { type: 'string', example: '나는 연락을 잘 하겠습니다.' },
+                  text5: { type: 'string', example: null },
+                  text6: { type: 'string', example: null },
+                  text7: { type: 'string', example: null },
+                  text8: { type: 'string', example: null },
+                  text9: { type: 'string', example: '끝난거같은데?' },
+                  text10: { type: 'string', example: null }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+    #swagger.responses[400] = {
+      description: '잘못된 요청',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              resultType: { type: 'string', example: 'FAIL' },
+              error: {
+                type: 'object',
+                properties: {
+                  errorCode: { type: 'string', example: 'CP002' },
+                  reason: { type: 'string', example: 'Invalid couple_id: 1ㅁㄴ1. Must be a valid integer.' },
+                  data: {
+                    type: 'object',
+                    properties: {
+                      couple_id: { type: 'string', example: '1ㅁㄴ1' }
+                    }
+                  }
+                }
+              },
+              success: { type: 'object', nullable: true, example: null }
+            }
+          }
+        }
+      }
+    };
+    #swagger.responses[404] = {
+      description: '커플 ID를 찾을 수 없음',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              resultType: { type: 'string', example: 'FAIL' },
+              error: {
+                type: 'object',
+                properties: {
+                  errorCode: { type: 'string', example: 'CP001' },
+                  reason: { type: 'string', example: 'Couple with id 5 not found.' },
+                  data: {
+                    type: 'object',
+                    properties: {
+                      couple_id: { type: 'integer', example: 5 }
+                    }
+                  }
+                }
+              },
+              success: { type: 'object', nullable: true, example: null }
+            }
+          }
+        }
+      }
+    };
+ */
+
+  const { couple_id } = req.params;
+  console.log('body:', req.body);
+  const promise = await putPromiseByCoupleIdService(couple_id, req.body);
   res.status(StatusCodes.OK).success(promise);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import swaggerUiExpress from 'swagger-ui-express';
 import swaggerAutogen from 'swagger-autogen';
 import morganMiddleware from './middlewares/morganMiddleware.js';
 import { getConflictsByMonth, getConflictsById } from './controllers/conflict.controller.js';
-import { getPromiseByCoupleId } from './controllers/promise.controller.js';
+import { getPromiseByCoupleId, putPromiseByCoupleId } from './controllers/promise.controller.js';
 dotenv.config();
 
 const app = express();
@@ -86,6 +86,7 @@ app.get('/', (req, res) => {
 app.get('/api/conflicts/:month', getConflictsByMonth);
 app.get('/api/conflicts/id/:conflict_id', getConflictsById);
 app.get('/api/promise/:couple_id', getPromiseByCoupleId);
+app.put('/api/promise/:couple_id', putPromiseByCoupleId);
 
 /****************전역 오류를 처리하기 위한 미들웨어*******************/
 app.use((err, req, res, next) => {

--- a/src/repositories/promise.repository.js
+++ b/src/repositories/promise.repository.js
@@ -21,38 +21,127 @@ export const getPromiseByCoupleIdRepository = async couple_id => {
       text10: true,
     },
   });
-  if (!promise) {
-    // Check if the couple_id exists in the Couple table
-    const coupleExists = await prisma.couple.findUnique({
-      where: { couple_id },
-      select: { couple_id: true },
-    });
+  // if (!promise) {
+  //   // Check if the couple_id exists in the Couple table
+  //   const coupleExists = await prisma.couple.findUnique({
+  //     where: { couple_id },
+  //     select: { couple_id: true },
+  //   });
 
-    if (!coupleExists) {
-      throw new coupleNotFoundError(`Couple with id ${couple_id} not found.`, { couple_id: couple_id });
-    }
+  //   if (!coupleExists) {
+  //     throw new coupleNotFoundError(`Couple with id ${couple_id} not found.`, { couple_id: couple_id });
+  //   }
 
-    // Log a message if the couple exists but no promise is found
+  //   // Log a message if the couple exists but no promise is found
+  //   const new_promise = await prisma.promise.create({
+  //     data: {
+  //       couple: {
+  //         connect: { couple_id },
+  //       },
+  //       text1: null,
+  //       text2: null,
+  //       text3: null,
+  //       text4: null,
+  //       text5: null,
+  //       text6: null,
+  //       text7: null,
+  //       text8: null,
+  //       text9: null,
+  //       text10: null,
+  //     },
+  //   });
+
+  //   return new_promise;
+  // }
+
+  return promise;
+};
+
+export const makeNewPromise = async couple_id => {
+  const new_promise = await prisma.promise.create({
+    data: {
+      couple: {
+        connect: { couple_id },
+      },
+      text1: null,
+      text2: null,
+      text3: null,
+      text4: null,
+      text5: null,
+      text6: null,
+      text7: null,
+      text8: null,
+      text9: null,
+      text10: null,
+    },
+  });
+  return new_promise;
+};
+
+// Function to check if a couple exists
+export const checkCoupleExists = async couple_id => {
+  const coupleExists = await prisma.couple.findUnique({
+    where: { couple_id },
+  });
+
+  console.log(coupleExists);
+  if (!coupleExists) {
+    console.log('!!!!!!!!!!!');
+    throw new coupleNotFoundError(`Couple with id ${couple_id} not found.`, { couple_id: couple_id });
+  }
+
+  return true;
+};
+
+// Function to check if a promise exists for the given couple_id
+export const checkPromiseExists = async couple_id => {
+  const promise_exists = await prisma.promise.findFirst({
+    where: { couple_id },
+  });
+  if (!promise_exists) {
+    return false;
+  }
+  return promise_exists;
+};
+
+// Function to update or create a promise for a couple
+export const updateOrCreatePromise = async (couple_id, updateData) => {
+  // Check if a promise exists
+  const existingPromise = await checkPromiseExists(couple_id);
+
+  if (!existingPromise) {
+    // Create a new promise if none exists
+    console.log(`Creating new promise for couple_id ${couple_id}.`);
     const newPromise = await prisma.promise.create({
       data: {
         couple: {
           connect: { couple_id },
         },
-        text1: null,
-        text2: null,
-        text3: null,
-        text4: null,
-        text5: null,
-        text6: null,
-        text7: null,
-        text8: null,
-        text9: null,
-        text10: null,
+        ...updateData,
       },
     });
-
     return newPromise;
   }
 
-  return promise;
+  // Update the existing promise
+  console.log(`Updating existing promise for couple_id ${couple_id}.`);
+  const updatedPromise = await prisma.promise.update({
+    where: { id: existingPromise.id },
+    data: {
+      couple: {
+        connect: { couple_id },
+      },
+      ...updateData,
+    },
+  });
+
+  return updatedPromise;
+};
+
+// Main function to manage promise updates by couple_id
+export const putPromiseByCoupleIdRepository = async (couple_id, updateData) => {
+  // Update or create the promise
+  const result = await updateOrCreatePromise(couple_id, updateData);
+
+  return result;
 };

--- a/src/services/promise.service.js
+++ b/src/services/promise.service.js
@@ -1,7 +1,20 @@
-import { getPromiseByCoupleIdRepository } from '../repositories/promise.repository.js';
+import { getPromiseByCoupleIdRepository, putPromiseByCoupleIdRepository } from '../repositories/promise.repository.js';
 import { promiseCoupleIdDTO } from '../dtos/promise.dto.js';
+import { checkCoupleExists } from '../repositories/promise.repository.js';
+import { checkPromiseExists } from '../repositories/promise.repository.js';
+import { makeNewPromise } from '../repositories/promise.repository.js';
 
 export const getPromiseByCoupleIdService = async couple_id => {
   const dto = promiseCoupleIdDTO(couple_id);
+  await checkCoupleExists(dto.couple_id);
+  if (await !checkPromiseExists(dto.couple_id)) {
+    return await makeNewPromise(dto.couple_id);
+  }
   return await getPromiseByCoupleIdRepository(dto.couple_id);
+};
+
+export const putPromiseByCoupleIdService = async (couple_id, body) => {
+  const dto = promiseCoupleIdDTO(couple_id);
+  await checkCoupleExists(dto.couple_id);
+  return await putPromiseByCoupleIdRepository(dto.couple_id, body);
 };


### PR DESCRIPTION
# 🚀 작업한 기능 설명 (Feature Description)
- 월별 다툼 내용을 가져오는 API를 구현했습니다.

---

## 🔍 작업 상세 (Implementation Details)

### ✅ 성공 응답 예시
```json
{
    "resultType": "SUCCESS",
    "error": null,
    "success": {
        "id": 1,
        "couple_id": 1,
        "text1": "나는 지각하지 않겠습니다.",
        "text2": "나는 지각하지 않겠습니다.",
        "text3": "나는 늦게까지 게임하지 않겠습니다.",
        "text4": "나는 연락을 잘 하겠습니다.",
        "text5": null,
        "text6": null,
        "text7": null,
        "text8": null,
        "text9": "끝난거같은데?",
        "text10": null
    }
}

```
### ❌ 실패 응답 예시(유저 조회 실패)
```json
{
    "resultType": "FAIL",
    "error": {
        "errorCode": "CP001",
        "reason": "Couple with id 5 not found.",
        "data": {
            "couple_id": 5
        }
    },
    "success": null
}
```
```
### ❌ 실패 응답 예시(유효하지 않은 파라미터)
```json
{
    "resultType": "FAIL",
    "error": {
        "errorCode": "CP002",
        "reason": "Invalid couple_id: 1ㅁㄴ1. Must be a valid integer.",
        "data": {
            "couple_id": "1ㅁㄴ1"
        }
    },
    "success": null
}
```